### PR TITLE
Update search_content_relevance.py

### DIFF
--- a/neurons/validators/reward/search_content_relevance.py
+++ b/neurons/validators/reward/search_content_relevance.py
@@ -164,7 +164,7 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
                 "arxiv.org": response.arxiv_search_results,
                 "wikipedia.org": response.wikipedia_search_results,
                 "reddit.com": response.reddit_search_results,
-                "news.ycombinator.com": response.hacker_news_search_results,
+                "ycombinator.com": response.hacker_news_search_results,
                 "youtube.com": response.youtube_search_results,
             }
 


### PR DESCRIPTION
The code that extracts domain from links, 
```
domain_parts = url.split("/")[2].split(".")
domain = ".".join(domain_parts[-2:])  # Extract the main domain
```
only extracts two components, so news.ycombinator.com fails.