### PR TITLE
Update web_scraper_actor.py

### DIFF
--- a/neurons/validators/apify/web_scraper_actor.py
+++ b/neurons/validators/apify/web_scraper_actor.py
@@ -30,7 +30,7 @@ class WebScraperActor:
                 "pageFunction": 'async function pageFunction(context) {\n    const { $, request, log } = context;\n\n    // The "$" property contains the Cheerio object which is useful\n    // for querying DOM elements and extracting data from them.\n    const pageTitle = $(\'title\').first().text();\n\n    // The "request" property contains various information about the web page loaded. \n    const url = request.url;\n    \n    // Use "log" object to print information to actor log.\n    log.info(\'Page scraped\', { url, pageTitle });\n\n    // Return an object with the data extracted from the page.\n    // It will be stored to the resulting dataset.\n    return {\n        url,\n        pageTitle\n    };\n}',
                 "postNavigationHooks": '// We need to return array of (possibly async) functions here.\n// The functions accept a single argument: the "crawlingContext" object.\n[\n    async (crawlingContext) => {\n        // ...\n    },\n]',
                 "preNavigationHooks": '// We need to return array of (possibly async) functions here.\n// The functions accept two arguments: the "crawlingContext" object\n// and "requestAsBrowserOptions" which are passed to the `requestAsBrowser()`\n// function the crawler calls to navigate..\n[\n    async (crawlingContext, requestAsBrowserOptions) => {\n        // ...\n    }\n]',
-                "proxyConfiguration": {"useApifyProxy": True},
+                "proxyConfiguration": {"useApifyProxy": True, "apifyProxyGroups": [ "RESIDENTIAL" ]},
                 "startUrls": [{"url": url} for url in urls],
             }
 


### PR DESCRIPTION
* Instruct the apify actor to use a residential proxy instead of the regular datacenter proxy
* This will help with instances where datacenter proxys are blocked by various sites returning a 403 error. For example almost all redding requests that the validators do fail with 403 which results in miners getting 0 score for reddit searches most of the time even though the provided results are valid
* There will be a cost increase because of this as residential proxies are charged at 9$/GB for the lowest apify plans. Not sure exactly how much traffic a validator would go through daily.