### PR TITLE
Feat/synthetic queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Welcome to Smart-Scrape, a cutting-edge tool hosted on the Bittensor network, de
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/surcyf123/smart-scrape.git
+   git clone https://github.com/Datura-ai/smart-scrape.git
    ```
 2. Install the requirements:
    ```bash

--- a/datura/__init__.py
+++ b/datura/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.149"
+__version__ = "0.0.150"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/datura/stream.py
+++ b/datura/stream.py
@@ -7,9 +7,10 @@ import aiohttp
 import json
 import asyncio
 import time
+import random
 
 
-async def collect_response(response, uid, start_time):
+async def collect_response(response: ScraperStreamingSynapse, uid, start_time):
     async for chunk in response:
         if isinstance(chunk, bt.Synapse):
             end_time = time.time()
@@ -27,23 +28,45 @@ async def collect_response(response, uid, start_time):
     return None
 
 
-async def collect_final_synapses(async_responses, uids, start_time, group_size=80):
-    # Split the async_responses into groups of size group_size
-    async_responses_groups = [
-        async_responses[i : i + group_size]
-        for i in range(0, len(async_responses), group_size)
+async def collect_responses(async_responses, uids, start_time):
+    tasks = [
+        asyncio.create_task(collect_response(resp, uid, start_time))
+        for resp, uid in zip(async_responses, uids)
     ]
 
-    final_synapses = []
+    return await asyncio.gather(*tasks)
 
-    for async_responses_group in async_responses_groups:
-        tasks = [
-            asyncio.create_task(collect_response(resp, uid, start_time))
-            for resp, uid in zip(async_responses_group, uids)
+
+async def collect_final_synapses(
+    async_responses, uids, start_time, max_execution_time, group_size=15
+):
+    final_synapses = [None] * len(async_responses)
+
+    if max_execution_time <= 60:
+        # Process all async_responses in sequence of groups
+
+        # Split the async_responses into groups of size group_size
+        async_responses_groups = [
+            async_responses[i : i + group_size]
+            for i in range(0, len(async_responses), group_size)
         ]
 
-        group_final_synapses = await asyncio.gather(*tasks)
-        final_synapses.extend(group_final_synapses)
+        group_indices = list(range(len(async_responses_groups)))
+        random.shuffle(group_indices)
+
+        for group_index in group_indices:
+            async_responses_group = async_responses_groups[group_index]
+            group_uids = uids[group_index * group_size : (group_index + 1) * group_size]
+
+            group_final_synapses = await collect_responses(
+                async_responses_group, group_uids, start_time
+            )
+
+            for i, synapse in enumerate(group_final_synapses):
+                final_synapses[group_index * group_size + i] = synapse
+    else:
+        # Process all async_responses in parallel
+        final_synapses = await collect_responses(async_responses, uids, start_time)
 
     return final_synapses
 

--- a/datura/tools/response_streamer.py
+++ b/datura/tools/response_streamer.py
@@ -43,24 +43,6 @@ class ResponseStreamer:
 
             bt.logging.trace(f"Streamed tokens: {token}")
 
-    async def send_texts_event(self):
-        texts = {}
-
-        for key in self.texts:
-            texts[key] = "".join(self.texts[key])
-
-        texts_response_body = {
-            "type": "texts",
-            "content": texts,
-        }
-
-        await self.send(
-            {
-                "type": "http.response.body",
-                "body": json.dumps(texts_response_body).encode("utf-8"),
-            }
-        )
-
     async def send_completion_event(self):
         completion_response_body = {
             "type": "completion",

--- a/datura/tools/tool_manager.py
+++ b/datura/tools/tool_manager.py
@@ -166,22 +166,9 @@ class ToolManager:
             self.response_streamer.get_full_text(),
         )
 
-        await self.response_streamer.send_texts_event()
-        await self.response_streamer.send_completion_event()
-
         await asyncio.gather(*tool_tasks)
 
-        completion_response_body = {
-            "type": "completion",
-            "content": self.response_streamer.get_full_text(),
-        }
-
-        await self.send(
-            {
-                "type": "http.response.body",
-                "body": json.dumps(completion_response_body).encode("utf-8"),
-            }
-        )
+        await self.response_streamer.send_completion_event()
 
         if self.response_streamer.more_body:
             await self.send(

--- a/datura/utils.py
+++ b/datura/utils.py
@@ -306,7 +306,7 @@ def resync_metagraph(self):
     self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
 
 
-async def save_logs(prompt, logs, netuid):
+async def save_logs(logs, netuid):
     logging_endpoint_url = None
 
     if netuid == 22:
@@ -321,7 +321,6 @@ async def save_logs(prompt, logs, netuid):
             result = await session.post(
                 logging_endpoint_url,
                 json={
-                    "prompt": prompt,
                     "logs": logs,
                 },
             )
@@ -334,7 +333,6 @@ async def save_logs(prompt, logs, netuid):
 
 async def save_logs_in_chunks(
     self,
-    prompt,
     responses,
     uids,
     rewards,
@@ -357,6 +355,7 @@ async def save_logs_in_chunks(
     try:
         logs = [
             {
+                "prompt": response.prompt,
                 "completion": response.completion,
                 # "prompt_analysis": response.prompt_analysis.dict(),
                 "data": response.miner_tweets,
@@ -449,7 +448,6 @@ async def save_logs_in_chunks(
 
         for chunk in log_chunks:
             await save_logs(
-                prompt=prompt,
                 logs=chunk,
                 netuid=netuid,
             )

--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -6,8 +6,8 @@ This comprehensive guide is designed to assist you in configuring the environmen
 
 ### Prerequisites
 
-- Access to a terminal interface.
-- Accounts on OpenAI, Weights & Biases, and Twitter Developer Portal.
+-   Access to a terminal interface.
+-   Accounts on OpenAI, Weights & Biases, and Twitter Developer Portal.
 
 ### Setting Up Variables
 
@@ -15,53 +15,38 @@ Here's a breakdown of the environment variables necessary for the Smart-Scrape s
 
 1. **OPENAI_API_KEY**
 
-   - **Usage**: Authenticates with the OpenAI API.
-   - **How to Obtain**: Sign up or log in at [OpenAI API](https://beta.openai.com/signup/), navigate to the API section, and generate a key.
-   - **Required for**: Validator and Miners.
+    - **Usage**: Authenticates with the OpenAI API.
+    - **How to Obtain**: Sign up or log in at [OpenAI API](https://beta.openai.com/signup/), navigate to the API section, and generate a key.
+    - **Required for**: Validator and Miners.
 
 2. **TWITTER_BEARER_TOKEN**
 
-   - **Usage**: Grants access to the Twitter API.
-   - **How to Obtain**: Create a Twitter Developer account, create an app at [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard), and generate a token.
-   - **Required for**: Miners exclusively.
+    - **Usage**: Grants access to the Twitter API.
+    - **How to Obtain**: Create a Twitter Developer account, create an app at [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard), and generate a token.
+    - **Required for**: Miners exclusively.
 
 3. **WANDB_API_KEY**
 
-   - **Usage**: For experiment tracking with Weights & Biases.
-   - **How to Obtain**: Sign up or log in at [Weights & Biases](https://wandb.ai/), and generate a key in your account settings.
-   - **Required for**: Validator and Miners.
+    - **Usage**: For experiment tracking with Weights & Biases.
+    - **How to Obtain**: Sign up or log in at [Weights & Biases](https://wandb.ai/), and generate a key in your account settings.
+    - **Required for**: Validator and Miners.
 
 4. **EXPECTED_ACCESS_KEY**
 
-   - **Usage**: Secures access to the validator service.
-   - **How to Create**: Generate a unique, strong, and random string.
-   - **Required for**: Validators exclusively.
+    - **Usage**: Secures access to the validator service.
+    - **How to Create**: Generate a unique, strong, and random string.
+    - **Required for**: Validators exclusively.
 
 5. **APIFY_API_KEY**
 
-   - **Usage**: Used for Apify actors
-   - **How to Create**: Sign up or log in at [Apify](https://apify.com/), and generate a key in your account settings.
+    - **Usage**: Used for Apify actors
+    - **How to Create**: Sign up or log in at [Apify](https://apify.com/), and generate a key in your account settings.
+    - **Required for**: Validator and Miners.
 
-6. **URL_SUBNET_18**
-
-   - **Usage**: URL for Subnet 18, utilized for scoring the relevance of summaries.
-   - **How to Create**: Generate a unique, strong, and random string.
-   - **Required for**: Validators exclusively.
-
-7. **SERPAPI_API_KEY**
-   - **Usage**: Used to search web using Serp API
-   - **How to Create**: Sign up or log in at [Serp API](https://serpapi.com/), and generate a key in your account settings.
-   - **Required for**: Miners exclusively.
-
-8. **DISCORD_MESSAGES_DB_URL**:
-   - **Usage**: Used to access bittensor discord messages/channels/users
-   - **How to Create**: Use `discord_db_url_generator.py` to get a read only database url. It will ask you for miner coldkey, and password for it after running the script.
-   - **Required for**: Miners exclusively.
-
-9. **PINECONE_API_KEY**:
-   - **Usage**: Used to read and write pinecone vector indexes for discord messages exclusively.
-   - **How to Create**: Sign up or login at [Pinecone](https://pinecone.io/), and generate a key in your account settings.
-   - **Required for**: Miners exclusively.
+6. **SERPAPI_API_KEY**
+    - **Usage**: Used to search web using Serp API
+    - **How to Create**: Sign up or log in at [Serp API](https://serpapi.com/), and generate a key in your account settings.
+    - **Required for**: Miners exclusively.
 
 ### Executing Commands for Setting Environment Variables
 
@@ -73,9 +58,6 @@ export TWITTER_BEARER_TOKEN=<your_twitter_bearer_token_here>  # Only for Miners
 export EXPECTED_ACCESS_KEY=<your_EXPECTED_ACCESS_KEY_here>  # Only for Validators
 export WANDB_API_KEY=<your_wandb_api_key_here>
 export APIFY_API_KEY=<your_apify_api_key_here>  # Only for Validators
-export URL_SUBNET_18=<your_url_subent_18>
-export DISCORD_MESSAGES_DB_URL=<discord_db_url>
-export PINECONE_API_KEY=<your_pinecone_api_key>
 ```
 
 ### Setting Environment Variables Using `.bashrc`
@@ -83,14 +65,11 @@ export PINECONE_API_KEY=<your_pinecone_api_key>
 If you prefer to use `.bashrc` for setting up environment variables, execute these commands:
 
 ```bash
-echo 'export OPENAI_API_KEY="<your_openai_api_key>"' >> ~/.bashrc
+echo 'export OPENAI_API_KEY="<your_openai_api_key>"' >> ~/.bashrc # Both for Validators and Miners
 echo 'export TWITTER_BEARER_TOKEN="<your_twitter_bearer_token>"' >> ~/.bashrc  # Only for Miners
 echo 'export EXPECTED_ACCESS_KEY="<your_EXPECTED_ACCESS_KEY>"' >> ~/.bashrc  # Only for Validators
-echo 'export WANDB_API_KEY="<your_wandb_api_key>"' >> ~/.bashrc
-echo 'export APIFY_API_KEY="<your_apify_api_key>"' >> ~/.bashrc
-echo 'export URL_SUBNET_18="<your_url_subent_18>"' >> ~/.bashrc
-echo 'export DISCORD_MESSAGES_DB_URL="<read_only_db_url>"' >> ~/.bashrc
-echo 'export PINECONE_API_KEY="<your_pinecone_api_key>"' >> ~/.bashrc
+echo 'export WANDB_API_KEY="<your_wandb_api_key>"' >> ~/.bashrc # Only for Validators
+echo 'export APIFY_API_KEY="<your_apify_api_key>"' >> ~/.bashrc # Both for Validators and Miners
 
 source ~/.bashrc
 ```

--- a/docs/running_a_miner.md
+++ b/docs/running_a_miner.md
@@ -11,21 +11,17 @@ Before starting, ensure you have:
 
 ## Setup Process
 
-### 1. Install the smart-scrape Repository
-First, install the smart-scrape repository. In your terminal, navigate to the smart-scrape directory and execute:
+## 1. Clone the smart-scrape repository and install dependencies
+Clone and install the smart-scrape repository in editable mode:
 
 ```sh
-python -m pip install -e ~/smart-scrape
-```
-
-### 2. Install Miner-Specific Requirements
-Install any additional requirements for the miner:
-
-```sh
+git clone https://github.com/Datura-ai/smart-scrape.git
+cd smart-scrape
 python -m pip install -r requirements.txt
+python -m pip install -e .
 ```
 
-### 3. Configure and Run the Miner
+### 2. Configure and Run the Miner
 Configure and launch the miner using PM2:
 
 ```sh
@@ -53,7 +49,6 @@ pm2 start neurons/miners/miner.py --interpreter /usr/bin/python3 --name miner_1 
 - `--miner.name`: Path for miner data (miner.root / (wallet_cold - wallet_hot) / miner.name).
 - `--miner.mock_dataset`: Set to True to use a mock dataset.
 - `--miner.blocks_per_epoch`: Number of blocks until setting weights on chain.
-- `--miner.intro_text`: If True, the miner will return intro text
 - `--miner.openai_summary_model`: OpenAI model used for summarizing content. Default gpt-3.5-turbo-0125
 - `--miner.openai_query_model`: OpenAI model used for generating queries. Default gpt-3.5-turbo-0125
 - `--miner.openai_fix_query_model`: "OpenAI model used for fixing queries. Default gpt-4-1106-preview

--- a/docs/running_a_validator.md
+++ b/docs/running_a_validator.md
@@ -12,19 +12,14 @@ conda create -n val python=3.10
 conda activate val
 ```
 
-## 1. Install Bittensor
-Install Bittensor directly from the GitHub repository on the `revolution` branch:
 
-```sh
-python -m pip install git+https://github.com/opentensor/bittensor.git@revolution
-```
-
-## 2. Clone the smart-scrape Repository
+## 1. Clone the smart-scrape repository and install dependencies
 Clone and install the smart-scrape repository in editable mode:
 
 ```sh
-git clone https://github.com/surcyf123/smart-scrape.git
+git clone https://github.com/Datura-ai/smart-scrape.git
 cd smart-scrape
+python -m pip install -r requirements.txt
 python -m pip install -e .
 ```
 
@@ -47,16 +42,10 @@ btcli subnets register --subtensor.network test
 Please ensure that all required environment variables are set prior to running the validator. For a comprehensive list and setup guide, refer to the [Environment Variables Guide](./env_variables.md).
 
 ## 6. Start the Process
-Identify available GPUs:
+Launch the process with `pm2`. Modify the command as needed:
 
 ```sh
-nvidia-smi
-```
-
-Launch the process with `pm2`, setting `CUDA_VISIBLE_DEVICES` to designate the GPU. Modify the command as needed:
-
-```sh
-CUDA_VISIBLE_DEVICES=1 pm2 start neurons/validators/api.py --interpreter /usr/bin/python3  --name validator_api -- 
+pm2 start neurons/validators/api.py --interpreter /usr/bin/python3  --name validator_api -- 
     --wallet.name <your-wallet-name>  
     --netuid 22 
     --wallet.hotkey <your-wallet-hot-key>  

--- a/docs/running_on_mainnet.md
+++ b/docs/running_on_mainnet.md
@@ -6,7 +6,7 @@ This tutorial shows how to use the bittensor mainnetwork to create a subnetwork 
 This clones and installs the datura if you dont already have it (if you do, skip this step)
 ```bash
 cd .. # back out of the subtensor repo
-git clone https://github.com/datura-ai/smart-scrape.git # Clone the smart-scrape repo
+git clone https://github.com/Datura-ai/smart-scrape.git # Clone the smart-scrape repo
 cd smart-scrape # Enter the  smart-scrape  repo
 python -m pip install -e . # Install the  smart-scrape  package
 ```

--- a/docs/running_on_testnet.md
+++ b/docs/running_on_testnet.md
@@ -7,7 +7,7 @@ This tutorial shows how to use the bittensor testnetwork to create a subnetwork 
 This clones and installs the datura if you dont already have it (if you do, skip this step)
 ```bash
 cd .. # back out of the subtensor repo
-git clone https://github.com/datura-ai/smart-scrape.git # Clone the smart-scrape repo
+git clone https://github.com/Datura-ai/smart-scrape.git # Clone the smart-scrape repo
 cd smart-scrape # Enter the  smart-scrape  repo
 python -m pip install -e . # Install the  smart-scrape  package
 ```

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -7,72 +7,60 @@
 
 # NOTE: Specification for miners may be different from validators
 
-version: '1.0.4' # update this version key as needed, ideally should match your release version
+version: "1.0.4" # update this version key as needed, ideally should match your release version
 
 compute_spec:
+    miner:
+        cpu:
+            min_cores: 4 # Minimum number of CPU cores
+            min_speed: 2.5 # Minimum speed per core (GHz)
+            recommended_cores: 8 # Recommended number of CPU cores
+            recommended_speed: 3.5 # Recommended speed per core (GHz)
+            architecture: "x86_64" # Architecture type (e.g., x86_64, arm64)
 
-  miner:
+        memory:
+            min_ram: 8 # Minimum RAM (GB)
+            min_swap: 4 # Minimum swap space (GB)
+            recommended_swap: 8 # Recommended swap space (GB)
+            ram_type: "DDR4" # RAM type (e.g., DDR4, DDR3, etc.)
 
-    cpu:
-      min_cores: 4            # Minimum number of CPU cores
-      min_speed: 2.5          # Minimum speed per core (GHz)
-      recommended_cores: 8    # Recommended number of CPU cores
-      recommended_speed: 3.5  # Recommended speed per core (GHz)
-      architecture: "x86_64"  # Architecture type (e.g., x86_64, arm64)
+        storage:
+            min_space: 48 # Minimum free storage space (GB)
+            recommended_space: 100 # Recommended free storage space (GB)
+            type: "SSD" # Preferred storage type (e.g., SSD, HDD)
+            min_iops: 1000 # Minimum I/O operations per second (if applicable)
+            recommended_iops: 5000 # Recommended I/O operations per second
 
-    memory:
-      min_ram: 8           # Minimum RAM (GB)
-      min_swap: 4          # Minimum swap space (GB)
-      recommended_swap: 8  # Recommended swap space (GB)
-      ram_type: "DDR4"     # RAM type (e.g., DDR4, DDR3, etc.)
+        os:
+            name: "Ubuntu" # Name of the preferred operating system(s)
+            version: 20.04 # Version of the preferred operating system(s)
 
-    storage:
-      min_space: 48           # Minimum free storage space (GB)
-      recommended_space: 100  # Recommended free storage space (GB)
-      type: "SSD"             # Preferred storage type (e.g., SSD, HDD)
-      min_iops: 1000          # Minimum I/O operations per second (if applicable)
-      recommended_iops: 5000  # Recommended I/O operations per second
+    validator:
+        cpu:
+            min_cores: 4 # Minimum number of CPU cores
+            min_speed: 2.5 # Minimum speed per core (GHz)
+            recommended_cores: 8 # Recommended number of CPU cores
+            recommended_speed: 3.5 # Recommended speed per core (GHz)
+            architecture: "x86_64" # Architecture type (e.g., x86_64, arm64)
 
-    os:
-      name: "Ubuntu"  # Name of the preferred operating system(s)
-      version: 20.04  # Version of the preferred operating system(s)
+        memory:
+            min_ram: 8 # Minimum RAM (GB)
+            min_swap: 4 # Minimum swap space (GB)
+            recommended_swap: 8 # Recommended swap space (GB)
+            ram_type: "DDR4" # RAM type (e.g., DDR4, DDR3, etc.)
 
-  validator:
+        storage:
+            min_space: 48 # Minimum free storage space (GB)
+            recommended_space: 100 # Recommended free storage space (GB)
+            type: "SSD" # Preferred storage type (e.g., SSD, HDD)
+            min_iops: 1000 # Minimum I/O operations per second (if applicable)
+            recommended_iops: 5000 # Recommended I/O operations per second
 
-    cpu:
-      min_cores: 4            # Minimum number of CPU cores
-      min_speed: 2.5          # Minimum speed per core (GHz)
-      recommended_cores: 8    # Recommended number of CPU cores
-      recommended_speed: 3.5  # Recommended speed per core (GHz)
-      architecture: "x86_64"  # Architecture type (e.g., x86_64, arm64)
-
-    gpu:
-      required: False                       # Does the application require a GPU?
-      min_vram: 24                         # Minimum GPU VRAM (GB)
-      recommended_vram: 48                 # Recommended GPU VRAM (GB)
-      cuda_cores: 1024                     # Minimum number of CUDA cores (if applicable)
-      min_compute_capability: 6.0          # Minimum CUDA compute capability
-      recommended_compute_capability: 7.0  # Recommended CUDA compute capability
-      recommended_gpu: "RTX A5000"       # Recommended GPU to purchase/rent
-
-    memory:
-      min_ram: 8          # Minimum RAM (GB)
-      min_swap: 4          # Minimum swap space (GB)
-      recommended_swap: 8  # Recommended swap space (GB)
-      ram_type: "DDR4"     # RAM type (e.g., DDR4, DDR3, etc.)
-
-    storage:
-      min_space: 48           # Minimum free storage space (GB)
-      recommended_space: 100  # Recommended free storage space (GB)
-      type: "SSD"             # Preferred storage type (e.g., SSD, HDD)
-      min_iops: 1000          # Minimum I/O operations per second (if applicable)
-      recommended_iops: 5000  # Recommended I/O operations per second
-
-    os:
-      name: "Ubuntu"  # Name of the preferred operating system(s)
-      version: 20.04  # Version of the preferred operating system(s)
+        os:
+            name: "Ubuntu" # Name of the preferred operating system(s)
+            version: 20.04 # Version of the preferred operating system(s)
 
 network_spec:
-  bandwidth:
-    download: 100  # Minimum download bandwidth (Mbps)
-    upload: 20     # Minimum upload bandwidth (Mbps)
+    bandwidth:
+        download: 100 # Minimum download bandwidth (Mbps)
+        upload: 20 # Minimum upload bandwidth (Mbps)

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -56,7 +56,7 @@ compute_spec:
       recommended_gpu: "RTX A5000"       # Recommended GPU to purchase/rent
 
     memory:
-      min_ram: 16          # Minimum RAM (GB)
+      min_ram: 8          # Minimum RAM (GB)
       min_swap: 4          # Minimum swap space (GB)
       recommended_swap: 8  # Recommended swap space (GB)
       ram_type: "DDR4"     # RAM type (e.g., DDR4, DDR3, etc.)

--- a/neurons/validators/organic_query_state.py
+++ b/neurons/validators/organic_query_state.py
@@ -153,6 +153,9 @@ class OrganicQueryState:
         """Called after metagraph resync to remove any hotkeys that are no longer registered"""
         hotkeys = [axon.hotkey for axon in axons]
 
+        original_history_count = len(self.organic_history)
+        original_penalties_count = len(self.organic_penalties)
+
         self.organic_history = {
             hotkey: synapses
             for hotkey, synapses in self.organic_history.items()
@@ -165,4 +168,11 @@ class OrganicQueryState:
             if hotkey in hotkeys
         }
 
-        bt.logging.info("Removed deregistered hotkeys from organic query state")
+        log_data = {
+            "organic_history": original_history_count - len(self.organic_history),
+            "organic_penalties": original_penalties_count - len(self.organic_penalties),
+        }
+
+        bt.logging.info(
+            f"Removed deregistered hotkeys from organic query state: {log_data}"
+        )

--- a/neurons/validators/penalty/penalty.py
+++ b/neurons/validators/penalty/penalty.py
@@ -22,14 +22,14 @@ from typing import List
 from abc import ABC, abstractmethod
 from neurons.validators.utils.tasks import Task
 
+
 class BasePenaltyModel(ABC):
     def __init__(self, max_penalty: float):
         self.max_penalty = max_penalty
 
     @property
     @abstractmethod
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
     def __str__(self) -> str:
         return str(self.name)
@@ -38,14 +38,14 @@ class BasePenaltyModel(ABC):
         return str(self.name)
 
     @abstractmethod
-    def calculate_penalties(task: Task, responses: List[bt.Synapse]) -> torch.FloatTensor:
-        ...
+    def calculate_penalties(
+        responses: List[bt.Synapse], tasks: List[Task]
+    ) -> torch.FloatTensor: ...
 
     def apply_penalties(
-        self, responses: List[bt.Synapse], task: Task
+        self, responses: List[bt.Synapse], tasks: List[Task]
     ) -> torch.FloatTensor:
-        # completions = [response.completion for response in responses]
-        raw_penalties = self.calculate_penalties(task, responses)
+        raw_penalties = self.calculate_penalties(responses, tasks)
 
         # Clip penalties between 0 and 1
         adjusted_penalties = torch.clip(raw_penalties, 0, 1)
@@ -63,3 +63,4 @@ class PenaltyModelType(Enum):
     task_validation_penalty = "task_validation_penalty"
     accuracy_match_penalty = "accuracy_match_penalty"
     link_validation_penalty = "link_validation_penalty"
+    streaming_penalty = "streaming_penalty"

--- a/neurons/validators/penalty/streaming_penalty.py
+++ b/neurons/validators/penalty/streaming_penalty.py
@@ -1,0 +1,46 @@
+import torch
+from typing import List
+from neurons.validators.utils.tasks import Task
+from neurons.validators.penalty.penalty import BasePenaltyModel, PenaltyModelType
+import bittensor as bt
+from datura.protocol import ScraperStreamingSynapse
+import tiktoken
+
+
+MAX_TOKENS_PER_CHUNK = 2
+PENALTY_PER_EXCEEDING_TOKEN = 0.01
+
+
+class StreamingPenaltyModel(BasePenaltyModel):
+    @property
+    def name(self) -> str:
+        return PenaltyModelType.streaming_penalty.value
+
+    def calculate_penalties(
+        self, responses: List[ScraperStreamingSynapse], tasks: List[Task]
+    ) -> torch.FloatTensor:
+        accumulated_penalties = torch.zeros(len(responses), dtype=torch.float32)
+        encoding = tiktoken.get_encoding("cl100k_base")
+
+        for index, response in enumerate(responses):
+            if not response.streamed_text_chunks:
+                accumulated_penalties[index] = 1
+                continue
+
+            token_counts = [
+                (len(encoding.encode(chunk)) if chunk is not None else 0)
+                for chunk in response.streamed_text_chunks
+            ]
+
+            # Apply penalty for exceeding max tokens per chunk
+            for token_count in token_counts:
+                if token_count > MAX_TOKENS_PER_CHUNK:
+                    penalty = (
+                        token_count - MAX_TOKENS_PER_CHUNK
+                    ) * PENALTY_PER_EXCEEDING_TOKEN
+
+                    accumulated_penalties[index] = min(
+                        1, accumulated_penalties[index] + penalty
+                    )
+
+        return accumulated_penalties

--- a/neurons/validators/penalty/streaming_penalty.py
+++ b/neurons/validators/penalty/streaming_penalty.py
@@ -23,13 +23,18 @@ class StreamingPenaltyModel(BasePenaltyModel):
         encoding = tiktoken.get_encoding("cl100k_base")
 
         for index, response in enumerate(responses):
-            if not response.streamed_text_chunks:
+            streamed_text_chunks = []
+
+            for chunks in response.text_chunks.values():
+                streamed_text_chunks.extend(chunks)
+
+            if not streamed_text_chunks:
                 accumulated_penalties[index] = 1
                 continue
 
             token_counts = [
                 (len(encoding.encode(chunk)) if chunk is not None else 0)
-                for chunk in response.streamed_text_chunks
+                for chunk in streamed_text_chunks
             ]
 
             # Apply penalty for exceeding max tokens per chunk

--- a/neurons/validators/reward/__init__.py
+++ b/neurons/validators/reward/__init__.py
@@ -1,3 +1,2 @@
-
-from .reward import BaseRewardModel
+from .reward import BaseRewardModel, BaseRewardEvent
 from .config import RewardModelType, DefaultRewardFrameworkConfig, RewardScoringType

--- a/neurons/validators/reward/performance_reward.py
+++ b/neurons/validators/reward/performance_reward.py
@@ -19,15 +19,12 @@
 import traceback
 import torch
 import bittensor as bt
-from typing import List, Tuple, Dict, Any, Union
-import sys
+from typing import List, Tuple, Dict
 import math
-import copy
 import json
 from .config import RewardModelType
 from .reward import BaseRewardModel, BaseRewardEvent
 from datura.protocol import ScraperStreamingSynapse
-
 from neurons.validators.constants import STEEPNESS, FACTOR
 
 
@@ -77,7 +74,7 @@ class PerformanceRewardModel(BaseRewardModel):
         return 0.2 * self.sigmoid_scale(axon_time, query_timeout)
 
     async def get_rewards(
-        self, prompt: str, responses: List[ScraperStreamingSynapse], name: str, uids
+        self, responses: List[ScraperStreamingSynapse], uids
     ) -> Tuple[List[BaseRewardEvent]]:
         """
         Returns a list of reward events for the given responses.

--- a/neurons/validators/reward/reward.py
+++ b/neurons/validators/reward/reward.py
@@ -21,7 +21,7 @@ import bittensor as bt
 from typing import List, Union
 from abc import abstractmethod
 from dataclasses import dataclass, asdict, fields
-from datura.protocol import ScraperStreamingSynapse, TwitterScraperTweet
+from datura.protocol import ScraperStreamingSynapse
 import re
 import numpy as np  # Ensure numpy is imported
 
@@ -62,7 +62,7 @@ class BaseRewardModel:
 
     @abstractmethod
     async def get_rewards(
-        self, prompt: str, responses: List[ScraperStreamingSynapse], name: str, uids
+        self, responses: List[ScraperStreamingSynapse], name: str, uids
     ) -> Union[torch.FloatTensor, dict]: ...
 
     def __init__(self) -> None:
@@ -216,9 +216,7 @@ class BaseRewardModel:
 
     async def apply(
         self,
-        prompt: str,
         responses: List[ScraperStreamingSynapse],
-        name: str,
         uids,
         organic_penalties: List[bool] = [],
     ) -> Union[torch.FloatTensor, dict]:
@@ -231,9 +229,7 @@ class BaseRewardModel:
             if resp.dendrite.status_code == 200
         ]
 
-        reward_events, val_score_responses = await self.get_rewards(
-            prompt, responses, name, uids
-        )
+        reward_events, val_score_responses = await self.get_rewards(responses, uids)
 
         # Reward each completion.
         reward_events = BaseRewardEvent.parse_reward_events(reward_events)

--- a/neurons/validators/scraper_validator.py
+++ b/neurons/validators/scraper_validator.py
@@ -1,7 +1,5 @@
-import math
 from datura.dataset.tool_return import ResponseOrder
 import torch
-import wandb
 import random
 import json
 import bittensor as bt
@@ -12,7 +10,7 @@ from datura.protocol import (
     TwitterUserSynapse,
     SearchSynapse,
 )
-from datura.stream import process_async_responses
+from datura.stream import collect_final_synapses
 from reward import RewardModelType, RewardScoringType
 from typing import List
 from utils.mock import MockRewardModel
@@ -176,7 +174,7 @@ class ScraperValidator:
 
     async def run_task_and_score(
         self,
-        task: TwitterTask,
+        tasks: List[TwitterTask],
         strategy=QUERY_MINERS.RANDOM,
         is_only_allowed_miner=True,
         # is_intro_text=False,
@@ -189,13 +187,11 @@ class ScraperValidator:
         response_order=ResponseOrder.SUMMARY_FIRST,
         timeout=60,
     ):
-        task_name = task.task_name
-        prompt = task.compose_prompt()
-
-        bt.logging.debug("run_task", task_name)
-
         # Record event start time.
-        event = {"name": task_name, "task_type": task.task_type}
+        event = {
+            "names": [task.task_name for task in tasks],
+            "task_types": [task.task_type for task in tasks],
+        }
         start_time = time.time()
 
         # Get random id on that step
@@ -209,71 +205,40 @@ class ScraperValidator:
         end_date = date_filter.end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
         axons = [self.neuron.metagraph.axons[uid] for uid in uids]
 
-        synapse = ScraperStreamingSynapse(
-            prompt=prompt,
-            model=self.model,
-            seed=self.seed,
-            # is_intro_text=is_intro_text,
-            start_date=start_date,
-            end_date=end_date,
-            date_filter_type=date_filter.date_filter_type.value,
-            tools=tools,
-            language=language,
-            region=region,
-            google_date_filter=google_date_filter,
-            response_order=response_order.value,
-            max_execution_time=timeout,
-        )
+        synapses = [
+            ScraperStreamingSynapse(
+                prompt=task.compose_prompt(),
+                model=self.model,
+                seed=self.seed,
+                start_date=start_date,
+                end_date=end_date,
+                date_filter_type=date_filter.date_filter_type.value,
+                tools=tools,
+                language=language,
+                region=region,
+                google_date_filter=google_date_filter,
+                response_order=response_order.value,
+                max_execution_time=timeout,
+            )
+            for task in tasks
+        ]
 
-        # Make calls in groups to avoid AioHTTP 100 connections limit
-        axon_group_1 = axons[:80]
-        axon_group_2 = axons[80:160]
-        axon_group_3 = axons[160:]
-
-        async_response_groups = await asyncio.gather(
-            *[
-                asyncio.create_task(
-                    self.neuron.dendrite1.forward(
-                        axons=axon_group_1,
-                        synapse=synapse,
-                        timeout=timeout,
-                        streaming=self.streaming,
-                        deserialize=False,
-                    )
-                ),
-                asyncio.create_task(
-                    self.neuron.dendrite2.forward(
-                        axons=axon_group_2,
-                        synapse=synapse,
-                        timeout=timeout,
-                        streaming=self.streaming,
-                        deserialize=False,
-                    )
-                ),
-                asyncio.create_task(
-                    self.neuron.dendrite3.forward(
-                        axons=axon_group_3,
-                        synapse=synapse,
-                        timeout=timeout,
-                        streaming=self.streaming,
-                        deserialize=False,
-                    )
-                ),
-            ]
-        )
-
-        async_responses = []
-
-        for async_response_group in async_response_groups:
-            async_responses.extend(async_response_group)
+        async_responses = [
+            self.neuron.dendrite1.call_stream(
+                target_axon=axon,
+                synapse=synapse.copy(),
+                timeout=timeout,
+                deserialize=False,
+            )
+            for axon, synapse in zip(axons, synapses)
+        ]
 
         return async_responses, uids, event, start_time
 
     async def compute_rewards_and_penalties(
         self,
         event,
-        prompt,
-        task,
+        tasks,
         responses,
         uids,
         start_time,
@@ -322,9 +287,7 @@ class ScraperValidator:
                     reward_event,
                     val_score_responses,
                     original_rewards,
-                ) = await reward_fn_i.apply(
-                    task.base_text, responses, task.task_name, uids, organic_penalties
-                )
+                ) = await reward_fn_i.apply(responses, uids, organic_penalties)
 
                 all_rewards.append(reward_i_normalized)
                 all_original_rewards.append(original_rewards)
@@ -358,9 +321,7 @@ class ScraperValidator:
                 )
 
             scattered_rewards = self.neuron.update_moving_averaged_scores(uids, rewards)
-            self.log_event(
-                task, event, start_time, uids, rewards, prompt=task.compose_prompt()
-            )
+            self.log_event(tasks, event, start_time, uids, rewards)
 
             scores = torch.zeros(len(self.neuron.metagraph.hotkeys))
             uid_scores_dict = {}
@@ -432,7 +393,7 @@ class ScraperValidator:
                 scores[uid] = reward  # Now 'uid' is an int, which is a valid key type
                 wandb_data["scores"][uid] = reward
                 wandb_data["responses"][uid] = response.completion
-                wandb_data["prompts"][uid] = prompt
+                wandb_data["prompts"][uid] = response.prompt
                 wandb_data["summary_reward"][uid] = summary_reward
                 wandb_data["twitter_reward"][uid] = twitter_reward
                 wandb_data["search_reward"][uid] = search_reward
@@ -440,7 +401,6 @@ class ScraperValidator:
 
             await self.neuron.update_scores(
                 wandb_data=wandb_data,
-                prompt=prompt,
                 responses=responses,
                 uids=uids,
                 rewards=rewards,
@@ -456,56 +416,52 @@ class ScraperValidator:
             bt.logging.error(f"Error in compute_rewards_and_penalties: {e}")
             raise e
 
-    def log_event(self, task, event, start_time, uids, rewards, prompt):
+    def log_event(self, tasks, event, start_time, uids, rewards):
         event.update(
             {
                 "step_length": time.time() - start_time,
-                "prompt": prompt,
+                "prompts": [task.compose_prompt() for task in tasks],
                 "uids": uids.tolist(),
                 "rewards": rewards.tolist(),
-                "propmt": task.base_text,
             }
         )
-        bt.logging.debug("Run Task event:", str(event))
 
-    async def process_async_responses(async_responses):
-        tasks = [resp for resp in async_responses]
-        responses = await asyncio.gather(*tasks)
-        for response in responses:
-            stream_text = "".join([chunk[1] for chunk in response if not chunk[0]])
-            if stream_text:
-                yield stream_text  # Yield stream text as soon as it's available
-            # Instead of returning, yield final synapse objects with a distinct flag
-            final_synapse = next((chunk[1] for chunk in response if chunk[0]), None)
-            if final_synapse:
-                yield (True, final_synapse)  # Yield final synapse with a flag
+        bt.logging.debug("Run Task event:", event)
 
     async def query_and_score(self, strategy=QUERY_MINERS.RANDOM):
         try:
-            dataset = QuestionsDataset()
-            tools = random.choice(self.tools)
-            prompt = await dataset.generate_new_question_with_openai(tools)
-
-            task_name = "augment"
-            task = TwitterTask(
-                base_text=prompt,
-                task_name=task_name,
-                task_type="twitter_scraper",
-                criteria=[],
-            )
-
             if not len(self.neuron.available_uids):
                 bt.logging.info("No available UIDs, skipping task execution.")
                 return
 
+            dataset = QuestionsDataset()
+            tools = random.choice(self.tools)
+
+            prompts = await asyncio.gather(
+                *[
+                    dataset.generate_new_question_with_openai(tools)
+                    for _ in range(len(self.neuron.available_uids))
+                ]
+            )
+
+            tasks = [
+                TwitterTask(
+                    base_text=prompt,
+                    task_name="augment",
+                    task_type="twitter_scraper",
+                    criteria=[],
+                )
+                for prompt in prompts
+            ]
+
             bt.logging.debug(
-                f"Query and score running with prompt: {prompt} and tools: {tools}"
+                f"Query and score running with prompts: {prompts} and tools: {tools}"
             )
 
             max_execution_time = random.choice(self.max_execution_times)
 
             async_responses, uids, event, start_time = await self.run_task_and_score(
-                task=task,
+                tasks=tasks,
                 strategy=strategy,
                 is_only_allowed_miner=False,
                 date_filter=get_random_date_filter(),
@@ -516,19 +472,13 @@ class ScraperValidator:
                 timeout=max_execution_time,
             )
 
-            final_synapses = []
-            async for value in process_async_responses(
+            final_synapses = await collect_final_synapses(
                 async_responses, uids, start_time
-            ):
-                if isinstance(value, bt.Synapse):
-                    final_synapses.append(value)
-                else:
-                    pass
+            )
 
             await self.compute_rewards_and_penalties(
                 event=event,
-                prompt=prompt,
-                task=task,
+                tasks=tasks,
                 responses=final_synapses,
                 uids=uids,
                 start_time=start_time,
@@ -600,11 +550,9 @@ class ScraperValidator:
                             yield value
             else:
                 # Collect specified uids from responses and score
-                async for value in process_async_responses(
+                final_synapses = await collect_final_synapses(
                     async_responses, uids, start_time
-                ):
-                    if isinstance(value, bt.Synapse):
-                        final_synapses.append(value)
+                )
 
             async def process_and_score_responses(uids):
                 if is_interval_query:

--- a/neurons/validators/scraper_validator.py
+++ b/neurons/validators/scraper_validator.py
@@ -473,7 +473,7 @@ class ScraperValidator:
             )
 
             final_synapses = await collect_final_synapses(
-                async_responses, uids, start_time
+                async_responses, uids, start_time, max_execution_time
             )
 
             await self.compute_rewards_and_penalties(
@@ -526,6 +526,8 @@ class ScraperValidator:
 
             tasks = [task]
 
+            max_execution_time = 10
+
             async_responses, uids, event, start_time = await self.run_task_and_score(
                 tasks=tasks,
                 strategy=QUERY_MINERS.ALL if specified_uids else QUERY_MINERS.RANDOM,
@@ -537,7 +539,7 @@ class ScraperValidator:
                 region=self.region,
                 date_filter=date_filter,
                 google_date_filter=self.date_filter,
-                timeout=10,
+                timeout=max_execution_time,
                 specified_uids=specified_uids,
             )
 
@@ -554,7 +556,7 @@ class ScraperValidator:
             else:
                 # Collect specified uids from responses and score
                 final_synapses = await collect_final_synapses(
-                    async_responses, uids, start_time
+                    async_responses, uids, start_time, max_execution_time
                 )
 
             async def process_and_score_responses(uids):

--- a/neurons/validators/scraper_validator.py
+++ b/neurons/validators/scraper_validator.py
@@ -22,9 +22,7 @@ from neurons.validators.reward.twitter_content_relevance import (
 from neurons.validators.reward.search_content_relevance import (
     WebSearchContentRelevanceModel,
 )
-from neurons.validators.reward.performance_reward import (
-    PerformanceRewardModel,
-)
+from neurons.validators.reward.performance_reward import PerformanceRewardModel
 from neurons.validators.reward.reward_llm import RewardLLM
 from neurons.validators.utils.tasks import TwitterTask, SearchTask
 
@@ -39,6 +37,7 @@ from datura.dataset.date_filters import (
     DateFilterType,
 )
 from neurons.validators.organic_query_state import OrganicQueryState
+from neurons.validators.penalty.streaming_penalty import StreamingPenaltyModel
 
 
 class ScraperValidator:
@@ -167,8 +166,7 @@ class ScraperValidator:
         ]
 
         self.penalty_functions = [
-            # LinkValidationPenaltyModel(max_penalty=0.7),
-            # AccuracyPenaltyModel(max_penalty=1),
+            StreamingPenaltyModel(max_penalty=1),
         ]
         self.twitter_api = TwitterAPIClient()
 
@@ -306,7 +304,7 @@ class ScraperValidator:
 
             for penalty_fn_i in self.penalty_functions:
                 raw_penalty_i, adjusted_penalty_i, applied_penalty_i = (
-                    penalty_fn_i.apply_penalties(responses, task)
+                    penalty_fn_i.apply_penalties(responses, tasks)
                 )
                 penalty_start_time = time.time()
                 rewards *= applied_penalty_i.to(self.neuron.config.neuron.device)

--- a/neurons/validators/scraper_validator.py
+++ b/neurons/validators/scraper_validator.py
@@ -42,10 +42,7 @@ from neurons.validators.penalty.streaming_penalty import StreamingPenaltyModel
 
 class ScraperValidator:
     def __init__(self, neuron: AbstractNeuron):
-        self.streaming = True
-        self.query_type = "text"
         self.model = "gpt-3.5-turbo-0125"
-        self.weight = 1
         self.seed = 1234
         self.neuron = neuron
         self.timeout = 180
@@ -168,7 +165,6 @@ class ScraperValidator:
         self.penalty_functions = [
             StreamingPenaltyModel(max_penalty=1),
         ]
-        self.twitter_api = TwitterAPIClient()
 
     async def run_task_and_score(
         self,

--- a/neurons/validators/utils/mock.py
+++ b/neurons/validators/utils/mock.py
@@ -17,10 +17,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 import torch
-import asyncio
-import bittensor as bt
-from reward import BaseRewardModel
-from typing import List
+from typing import Union, List
+from reward import BaseRewardModel, BaseRewardEvent
+from datura.protocol import ScraperStreamingSynapse
 
 
 class MockRewardModel(BaseRewardModel):
@@ -43,9 +42,23 @@ class MockRewardModel(BaseRewardModel):
     def set_counter_to_half(self):
         pass
 
-    def apply(self, prompt: str, completion: List[str], name: str, uids) -> torch.FloatTensor:
-        mock_reward = torch.tensor([1 for _ in completion], dtype=torch.float32)
-        return mock_reward, {}
+    async def apply(
+        self,
+        responses: List[ScraperStreamingSynapse],
+        uids,
+        organic_penalties: List[bool] = [],
+    ) -> Union[torch.FloatTensor, dict]:
+        reward_normalized = torch.tensor([1 for _ in responses], dtype=torch.float32)
+        reward_events = [BaseRewardEvent(reward=1) for _ in responses]
+        grouped_val_score_responses = [[{}] for _ in responses]
+        original_rewards = torch.tensor([1 for _ in responses], dtype=torch.float32)
+
+        return (
+            reward_normalized,
+            reward_events,
+            grouped_val_score_responses,
+            original_rewards,
+        )
 
     def reset(self):
         return self

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -209,7 +209,6 @@ class Neuron(AbstractNeuron):
     async def update_scores(
         self,
         wandb_data,
-        prompt,
         responses,
         uids,
         rewards,
@@ -226,7 +225,6 @@ class Neuron(AbstractNeuron):
             asyncio.create_task(
                 save_logs_in_chunks(
                     self,
-                    prompt=prompt,
                     responses=responses,
                     uids=uids,
                     rewards=rewards,

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -222,6 +222,8 @@ class Neuron(AbstractNeuron):
             if self.config.wandb_on:
                 wandb.log(wandb_data)
 
+            weights = await self.run_sync_in_async(lambda: get_weights(self))
+
             asyncio.create_task(
                 save_logs_in_chunks(
                     self,
@@ -239,7 +241,7 @@ class Neuron(AbstractNeuron):
                     tweet_scores=val_score_responses_list[0],
                     search_scores=val_score_responses_list[1],
                     summary_link_scores=val_score_responses_list[2],
-                    weights=get_weights(self),
+                    weights=weights,
                     neuron=neuron,
                     netuid=self.config.netuid,
                     organic_penalties=organic_penalties,


### PR DESCRIPTION
- Generate unique synthetic prompts for all miners
- Update reward models to use prompt from each synapse
- Resync metagraph in miner
- Update docs including: env variables, min requirements, running a validator and miner, replace old Github repo url
- Add penalty for not streaming response 
- In case of low timeouts collect synapses in groups in sequence to avoid load and delays
- Remove sending "texts" event from tool manager and processing in process stream response, summary texts will be computed from streamed chunks in the validator side.