### PR TITLE
Hotfix: summary

### DIFF
--- a/datura/__init__.py
+++ b/datura/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.163"
+__version__ = "0.0.164"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/datura/protocol.py
+++ b/datura/protocol.py
@@ -346,7 +346,7 @@ class ScraperStreamingSynapse(bt.StreamingSynapse):
         links_per_completion = 10
         links_expected = len(completions) * links_per_completion
 
-        completions = {key: value for key, value in completions.items() if value}
+        completions = {key: value for key, value in completions.items()}
 
         return completions, links_expected
 

--- a/neurons/validators/reward/summary_relevance.py
+++ b/neurons/validators/reward/summary_relevance.py
@@ -287,17 +287,25 @@ class SummaryRelevanceRewardModel(BaseRewardModel):
                 f"SummaryRelevanceRewardModel | Calculating {len(responses)} rewards (typically < 1 sec/reward)."
             )
 
+            # Same random completion will be used for all responses
+            random_summary_key = random.choice(
+                list(responses[0].get_all_completions().keys())
+            )
+
             # Choose random toolkit summary to score
             random_completions = []
 
             for response in responses:
                 # Get all available completions based on the tools used and choose random summary (Twitter, Search, Reddit, Hacker News)
                 completions = response.get_all_completions()
-                completions_list = list(completions.items())
+                random_completion = completions.get(random_summary_key, "")
+
+                # Check if all summaries are returned
+                is_full = all(completion for completion in completions.values())
 
                 random_completions.append(
-                    random.choice(completions_list)
-                    if completions_list
+                    (random_summary_key, random_completion)
+                    if random_completion and is_full
                     else (None, None)
                 )
 


### PR DESCRIPTION
- Fix ignoring empty search completions
- Use same random completion for all miner responses
- Fail response if one of the summaries is missed